### PR TITLE
Rebuild glew 2.1.0 for aarch64 and osx-64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -83,7 +83,6 @@ test:
 about:
   home: http://glew.sourceforge.net/
   license: BSD-3-Clause
-  license_family: BSD
   license_file: LICENSE.txt
   summary: "The OpenGL Extension Wrangler Library"
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,7 +16,7 @@ source:
 build:
   number: 3
   # Missing CDT packages on s390x and ppc64le
-  skip: True  # [s390x or ppc64le]
+  skip: True  # [win or s390x or ppc64le]
   run_exports:
     - {{ pin_subpackage('glew', max_pin='x.x') }}
 
@@ -27,6 +27,7 @@ requirements:
     - cmake
     - make                               # [unix]
     - pkg-config                         # [unix]
+    - patch                              # [not win]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - {{ cdt('libx11-devel') }}          # [linux]
     - {{ cdt('libxext-devel') }}         # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,6 +15,8 @@ source:
 
 build:
   number: 2
+  # Missing CDT packages on s390x and ppc64le
+  skip: True  # [s390x or ppc64le]
   run_exports:
     - {{ pin_subpackage('glew', max_pin='x.x') }}
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,12 +54,8 @@ requirements:
     - {{ cdt('alsa-lib') }}              # [linux]
   host:
     - libglu                         # [linux]
-    - xorg-libx11                    # [linux]
-    - xorg-libxext                   # [linux]
   run:
     - libglu                         # [linux]
-    - xorg-libx11                    # [linux]
-    - xorg-libxext                   # [linux]
 
 # Tests require visual context not present on CIs
 test:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -86,6 +86,7 @@ test:
 about:
   home: http://glew.sourceforge.net/
   license: BSD-3-Clause
+  license_family: BSD
   license_file: LICENSE.txt
   summary: "The OpenGL Extension Wrangler Library"
   description: |

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,13 +10,11 @@ source:
   fn: {{ name }}-{{ version }}.tgz
   url: {{ dev_url }}/releases/download/{{ name }}-{{ version }}/{{ name }}-{{ version }}.tgz
   sha256: 04de91e7e6763039bc11940095cd9c7f880baba82196a7765f727ac05a993c95
-  patches:
-    - CMakeLists.patch  # [win and vc<14]
 
 build:
   number: 3
   # Missing CDT packages on s390x and ppc64le
-  skip: True  # [win or s390x or ppc64le]
+  skip: True  # [s390x or ppc64le]
   run_exports:
     - {{ pin_subpackage('glew', max_pin='x.x') }}
   missing_dso_whitelist:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -71,8 +71,10 @@ test:
     - cmake
     - make                           # [unix]
     - {{ cdt('libselinux') }}        # [linux]
+    - {{ cdt('libxau') }}            # [linux]
     - {{ cdt('libxcb') }}            # [linux]
     - {{ cdt('libxdamage') }}        # [linux]
+    - {{ cdt('libxext') }}           # [linux]
     - {{ cdt('libxfixes') }}         # [linux]
     - {{ cdt('libxxf86vm') }}        # [linux]
     - {{ cdt('mesa-libgl-devel') }}  # [linux]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,9 @@ build:
   skip: True  # [win or s390x or ppc64le]
   run_exports:
     - {{ pin_subpackage('glew', max_pin='x.x') }}
+  missing_dso_whitelist:
+    - '**/libc.so.*'
+    - '**/libGLEW.*'
 
 requirements:
   build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - CMakeLists.patch  # [win and vc<14]
 
 build:
-  number: 2
+  number: 3
   # Missing CDT packages on s390x and ppc64le
   skip: True  # [s390x or ppc64le]
   run_exports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,7 +28,6 @@ requirements:
     - cmake
     - make                               # [unix]
     - pkg-config                         # [unix]
-    - patch                              # [not win]
     - {{ cdt('xorg-x11-proto-devel') }}  # [linux]
     - {{ cdt('libx11-devel') }}          # [linux]
     - {{ cdt('libxext-devel') }}         # [linux]


### PR DESCRIPTION
This is a rebuild to also cover osx-64 and aarch64. Since modifications were necessary and it is not entirely clear how build no. 2 was integrated, I'm also bumping the build number. This is a dependency of vtk.